### PR TITLE
[sqs-lambda] Remove legacy defaults and make construct more generale purpose  

### DIFF
--- a/packages/datadog/README.md
+++ b/packages/datadog/README.md
@@ -12,21 +12,32 @@ npm install @treedom/cdk-constructs-datadog
 
 ## Usage
 
-This package exports an `AddDatadogToLambdas` aspect that can be used to automatically add Datadog monitoring to Lambda functions in your CDK stack.
+This package exports an `AddDatadogToLambdasAspect` aspect that can be used to automatically add Datadog monitoring to Lambda functions in your CDK stack.
 
 ```typescript
 import { Aspects } from 'aws-cdk-lib';
-import { AddDatadogToLambdas } from '@treedom/cdk-constructs-datadog';
+import { AddDatadogToLambdasAspect } from '@treedom/cdk-constructs-datadog';
 import { DatadogLambda } from 'datadog-cdk-constructs-v2';
 
 // Create a DatadogLambda instance
 const datadogLambda = new DatadogLambda(this, 'DatadogLambda', {
   // Configure your Datadog Lambda as needed
+    site: "datadoghq.eu",
+    apiKeySecretArn: "arn:my-arn",
+    env: "test",
+    nodeLayerVersion: 115,
+    extensionLayerVersion: 65,
+    captureLambdaPayload: true,
+    sourceCodeIntegration: true,
+    logLevel: "warn",
+    service: "my-service",
+    redirectHandler: false,<>
 });
 
 // Create the AddDatadogToLambdas aspect
-const datadogAspect = new AddDatadogToLambdas('DatadogAspect', {
+const datadogAspect = new AddDatadogToLambdasAspect({
   datadog: datadogLambda,
+  extensionVersion: "next" 
 });
 
 // Apply the aspect to your stack

--- a/packages/datadog/src/lambda-aspect.ts
+++ b/packages/datadog/src/lambda-aspect.ts
@@ -5,24 +5,28 @@ import { DatadogLambda } from "datadog-cdk-constructs-v2";
 
 export type DatadogLambdaAspectProps = {
   datadog: DatadogLambda;
+  extensionVersion?: "next";
 };
 
-export class AddDatadogToLambdas implements IAspect {
+export class AddDatadogToLambdasAspect implements IAspect {
   public readonly datadog: DatadogLambda;
+  public readonly extensionVersion: DatadogLambdaAspectProps["extensionVersion"];
 
   constructor(props: DatadogLambdaAspectProps) {
     this.datadog = props.datadog;
+    this.extensionVersion = props.extensionVersion;
   }
 
   public visit(node: IConstruct): void {
     // See that we're dealing with a CfnBucket
     if (node instanceof lambda.Function) {
       const lambda = node;
-      // Check for versioning property, exclude the case where the property
-      // can be a token (IResolvable).
-      lambda.addEnvironment("DD_EXTENSION_VERSION", "next");
 
-      // If no extension is set, this envs are not set
+      if (this.extensionVersion) {
+        lambda.addEnvironment("DD_EXTENSION_VERSION", this.extensionVersion);
+      }
+
+      // If no extension is set, this envs are not automatically set by Datadog Construct
       if (!this.datadog.props.extensionLayerVersion) {
         lambda.addEnvironment("DD_VERSION", lambda.currentVersion.toString());
 

--- a/packages/datadog/test/lambda-aspect.test.ts
+++ b/packages/datadog/test/lambda-aspect.test.ts
@@ -5,7 +5,7 @@ import * as cdk from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { DatadogLambda } from "datadog-cdk-constructs-v2";
 
-import { AddDatadogToLambdas } from "../src/lambda-aspect.js";
+import { AddDatadogToLambdasAspect } from "../src/lambda-aspect.js";
 
 test("should set envs and layers to all lambdas in stack", async (t) => {
   await t.test("when extensionLayerVersion is true", (t) => {
@@ -35,7 +35,9 @@ test("should set envs and layers to all lambdas in stack", async (t) => {
       redirectHandler: false,
     });
 
-    cdk.Aspects.of(app).add(new AddDatadogToLambdas({ datadog }));
+    cdk.Aspects.of(app).add(
+      new AddDatadogToLambdasAspect({ datadog, extensionVersion: "next" }),
+    );
 
     // Prepare the stack for assertions.
     const template = Template.fromStack(testStack);
@@ -107,7 +109,7 @@ test("should set envs and layers to all lambdas in stack", async (t) => {
       redirectHandler: false,
     });
 
-    cdk.Aspects.of(app).add(new AddDatadogToLambdas({ datadog }));
+    cdk.Aspects.of(app).add(new AddDatadogToLambdasAspect({ datadog }));
 
     // Prepare the stack for assertions.
     const template = Template.fromStack(testStack);
@@ -130,7 +132,7 @@ test("should set envs and layers to all lambdas in stack", async (t) => {
       ],
       Environment: {
         Variables: {
-          DD_EXTENSION_VERSION: "next",
+          DD_EXTENSION_VERSION: Match.absent(),
           DD_CAPTURE_LAMBDA_PAYLOAD: "true",
           DD_LOG_LEVEL: "warn",
           DD_ENV: "test",
@@ -171,7 +173,7 @@ test("should set DD_TAGS when specified in the constuct", (t) => {
     tags: "dd-tag1,dd-tag2",
   });
 
-  cdk.Aspects.of(app).add(new AddDatadogToLambdas({ datadog }));
+  cdk.Aspects.of(app).add(new AddDatadogToLambdasAspect({ datadog }));
 
   // Prepare the stack for assertions.
   const template = Template.fromStack(testStack);

--- a/packages/sqs-lambda/README.md
+++ b/packages/sqs-lambda/README.md
@@ -71,16 +71,16 @@ class MyStack extends Stack {
 
 The `EventBridgeSqsLambdaProps` interface includes the following properties:
 
-- `envPrefix`: A string used as a prefix for naming resources.
-- `deadLetterQueueProps`: (Optional) Properties for the dead-letter queue.
-- `readQueueProps`: (Optional) Properties for the main SQS queue, including an optional `retryAttempts` number.
-- `ruleProps`: Properties for the EventBridge rule(s).
-- `nodejsFunctionProps`: (Optional) Properties for the NodeJS Lambda function.
-- `eventSourceProps`: (Optional) Properties for the SQS event source.
+- `queue`: (Optional) Properties for the main SQS queue, including an optional `retryAttempts` number.
+- `queueDlq`: (Optional) Properties for the dead-letter queue.
+- `rules`: (Optional) Array of EventBridge rules configuration.
+- `lambda`: (Optional) Properties for the NodeJS Lambda function.
+- `eventSource`: (Optional) Properties for the SQS event source.
+- `namesPrefix`: (Optional) A string used as a prefix for naming resources.
 
 ### LambdaMaxScalingAspect
 
-This class implements the `IAspect` interface and can be used to verify if some lambdas exceeds the maximum scaling specified. If the limit is exceeded an error Annotation on the lambda will be emitted.
+This class implements the `IAspect` interface and can be used to verify if some lambdas exceed the maximum allowed concurrency. Default maximum concurrency is 10 if not specified. maximum scaling specified. If the limit is exceeded an error Annotation on the lambda will be emitted.
 
 #### Usage
 

--- a/packages/sqs-lambda/src/eventbridge.ts
+++ b/packages/sqs-lambda/src/eventbridge.ts
@@ -20,85 +20,28 @@ export type EventBridgeSqsLambdaRuleProps = Required<
   RuleProps;
 
 export type EventBridgeSqsLambdaProps = {
-  envPrefix: string;
-  deadLetterQueueProps?: QueueProps;
-  readQueueProps?: QueueProps & {
-    retryAttempts?: number;
-  };
-  ruleProps:
-    | EventBridgeSqsLambdaRuleProps
-    | Array<
-        EventBridgeSqsLambdaRuleProps & Required<Pick<RuleProps, "ruleName">>
-      >;
-  nodejsFunctionProps?: NodejsFunctionProps;
-  eventSourceProps?: SqsEventSourceProps;
+  queue?: QueueProps & { retryAttempts?: number };
+  queueDlq?: QueueProps;
+  rule?: EventBridgeSqsLambdaRuleProps;
+  rules?: Array<
+    EventBridgeSqsLambdaRuleProps & Required<Pick<RuleProps, "ruleName">>
+  >;
+  lambda: NodejsFunctionProps;
+  eventSource?: SqsEventSourceProps;
+  namesPrefix?: string;
 };
 
+export type EventBridgeSqsLambdaDefaults = Partial<
+  Omit<EventBridgeSqsLambdaProps, "rules">
+>;
+
 export class EventBridgeSqsLambda extends Construct {
-  public readonly deadLetterQueue: Queue;
-  public readonly readQueue: Queue;
-  public readonly eventSource: SqsEventSource;
-  public readonly rules: Array<Rule> = [];
-  public readonly lambda: NodejsFunction;
-
-  public readonly envPrefix: string;
-
-  constructor(scope: Construct, id: string, props: EventBridgeSqsLambdaProps) {
-    super(scope, id);
-
-    this.envPrefix = props.envPrefix;
-
-    // SQS Dead Letter Queue
-    this.deadLetterQueue = new Queue(this, `${id}DLQueue`, {
-      fifo: props.deadLetterQueueProps?.fifo, // Dead letter queues must be FIFO if the source queue is FIFO
-      queueName: `${props.envPrefix}-${id}DLQueue${
-        props.readQueueProps?.fifo ? ".fifo" : ""
-      }`, // AWS requires the .fifo suffix for FIFO queues
-      ...props.deadLetterQueueProps,
-    });
-
-    // SQS Queue
-    this.readQueue = new Queue(this, `${id}Queue`, {
-      queueName: `${props.envPrefix}-${id}Queue${
-        props.readQueueProps?.fifo ? ".fifo" : ""
-      }`, // AWS requires the .fifo suffix for FIFO queues
-      deadLetterQueue: {
-        queue: this.deadLetterQueue,
-        maxReceiveCount: props.readQueueProps?.retryAttempts ?? 10,
-        ...props.readQueueProps?.deadLetterQueue,
-      },
-      ...props.readQueueProps,
-    });
-
-    // SQS EventSource
-    this.eventSource = new SqsEventSource(this.readQueue, {
-      reportBatchItemFailures: true,
-      maxConcurrency: 5,
-      batchSize: 10,
-      ...props.eventSourceProps,
-    });
-
-    // EventBridge Rule
-    if (Array.isArray(props.ruleProps)) {
-      for (const rule of props.ruleProps) {
-        const { ruleName, ...ruleProps } = rule;
-        this.addRule(ruleName, ruleProps);
-      }
-    } else {
-      this.addRule(`${id}Rule`, {
-        ruleName: `${props.envPrefix}-${id}Rule`,
-        ...props.ruleProps,
-      });
-    }
-
-    // Lambda
-    this.lambda = new NodejsFunction(this, `${id}Lambda`, {
+  protected static defaults: EventBridgeSqsLambdaDefaults = {
+    lambda: {
       architecture: Architecture.ARM_64,
       runtime: Runtime.NODEJS_20_X,
 
-      functionName: `${props.envPrefix}-${id}Lambda`,
       logRetention: RetentionDays.THREE_MONTHS,
-      memorySize: 256,
 
       timeout: Duration.seconds(10),
 
@@ -107,24 +50,116 @@ export class EventBridgeSqsLambda extends Construct {
         externalModules: [],
         sourceMap: true,
       },
+    },
+    eventSource: {
+      maxConcurrency: 5,
+      reportBatchItemFailures: true,
+    },
+  };
 
-      ...props.nodejsFunctionProps,
+  public readonly queueDlq: Queue;
+  public readonly queue: Queue;
+  public readonly lambdaSource: SqsEventSource;
+  public readonly rules: Array<Rule> = [];
+  public readonly lambda: NodejsFunction;
+
+  public readonly namesPrefix?: string;
+
+  constructor(scope: Construct, id: string, props: EventBridgeSqsLambdaProps) {
+    super(scope, id);
+
+    this.namesPrefix = props.namesPrefix;
+
+    // SQS Dead Letter Queue
+    this.queueDlq = new Queue(this, `DLQueue`, {
+      ...EventBridgeSqsLambda.defaults.queueDlq,
+      queueName: this.getDefaultName(
+        this.getQueueName(`DLQueue`, props.queue?.fifo),
+      ),
+      fifo: props.queue?.fifo, // Dead letter queues must be FIFO if the source queue is FIFO
+      ...props.queueDlq,
+    });
+
+    // SQS Queue
+    this.queue = new Queue(this, `Queue`, {
+      ...EventBridgeSqsLambda.defaults.queue,
+      queueName: this.getDefaultName(
+        this.getQueueName(`Queue`, props.queue?.fifo),
+      ),
+      ...props.queue,
+      deadLetterQueue: {
+        queue: this.queueDlq,
+        maxReceiveCount: props.queue?.retryAttempts ?? 10,
+        ...props.queue?.deadLetterQueue,
+      },
+    });
+
+    // SQS EventSource
+    this.lambdaSource = new SqsEventSource(this.queue, {
+      ...EventBridgeSqsLambda.defaults.eventSource,
+      ...props.eventSource,
+    });
+
+    // EventBridge Rule
+    if (props.rules) {
+      for (const rule of props.rules) {
+        const { ruleName, ...ruleProps } = rule;
+        this.addRule(ruleName, ruleProps);
+      }
+    }
+
+    if (props.rule) {
+      this.addRule(`Rule`, {
+        ruleName: this.getDefaultName(`Rule`),
+        ...props.rule,
+      });
+    }
+
+    if (!this.rules) {
+      throw new Error("At least one rule must be specified");
+    }
+
+    // Lambda
+    this.lambda = new NodejsFunction(this, `Lambda`, {
+      ...EventBridgeSqsLambda.defaults.lambda,
+      functionName: this.getDefaultName(`Lambda`),
+      ...props.lambda,
     });
 
     this.lambda.addEnvironment("NODE_OPTIONS", "--enable-source-maps");
 
-    this.lambda.addEventSource(this.eventSource);
+    this.lambda.addEventSource(this.lambdaSource);
+  }
+
+  static setDefaults(defaultProps: EventBridgeSqsLambdaDefaults) {
+    EventBridgeSqsLambda.defaults = defaultProps;
   }
 
   addRule(ruleName: string, ruleProps: EventBridgeSqsLambdaRuleProps) {
     const rule = new Rule(this, `${ruleName}Rule`, {
+      ...EventBridgeSqsLambda.defaults.rule,
       ruleName,
       ...ruleProps,
     });
-    rule.addTarget(new SqsQueue(this.readQueue));
+    rule.addTarget(new SqsQueue(this.queue));
 
     this.rules.push(rule);
 
     return rule;
+  }
+
+  getDefaultName(name: string) {
+    const nameSuffix = `${this.node.id}${name}`;
+
+    if (this.namesPrefix) {
+      return `${this.namesPrefix}-${nameSuffix}`;
+    }
+
+    return nameSuffix;
+  }
+
+  getQueueName(name: string, fifo = false) {
+    // AWS requires the .fifo suffix for FIFO queues
+    return fifo ? `${name}.fifo` : name;
   }
 }

--- a/packages/sqs-lambda/test/eventbridge.test.ts
+++ b/packages/sqs-lambda/test/eventbridge.test.ts
@@ -13,8 +13,8 @@ test("should set all required resources", () => {
   const testStack = new cdk.Stack(app, "TestStack");
 
   new EventBridgeSqsLambda(testStack, "TestConstruct", {
-    envPrefix: "mytest",
-    ruleProps: {
+    namesPrefix: "mytest",
+    rule: {
       eventBus: EventBus.fromEventBusName(testStack, "EventBus", `mybus`),
       eventPattern: {
         detailType: ["MyEvent"],
@@ -23,16 +23,16 @@ test("should set all required resources", () => {
         },
       },
     },
-    readQueueProps: {
+    queue: {
       retryAttempts: 17,
     },
-    deadLetterQueueProps: {
+    queueDlq: {
       visibilityTimeout: cdk.Duration.seconds(10),
     },
-    nodejsFunctionProps: {
+    lambda: {
       entry: path.join(__dirname, "./mock/mock.lambda.js"),
     },
-    eventSourceProps: {
+    eventSource: {
       batchSize: 5,
     },
   });
@@ -43,7 +43,6 @@ test("should set all required resources", () => {
     FunctionName: "mytest-TestConstructLambda",
     Runtime: Match.stringLikeRegexp("nodejs"),
     Timeout: 10,
-    MemorySize: 256,
     Environment: {
       Variables: {
         NODE_OPTIONS: "--enable-source-maps",
@@ -75,7 +74,7 @@ test("should set all required resources", () => {
     Targets: [
       {
         Arn: {
-          "Fn::GetAtt": ["TestConstructTestConstructQueue8E078832", "Arn"],
+          "Fn::GetAtt": ["TestConstructQueue447D1F58", "Arn"],
         },
       },
     ],
@@ -83,9 +82,9 @@ test("should set all required resources", () => {
 
   template.hasResourceProperties("AWS::Lambda::EventSourceMapping", {
     EventSourceArn: {
-      "Fn::GetAtt": ["TestConstructTestConstructQueue8E078832", "Arn"],
+      "Fn::GetAtt": ["TestConstructQueue447D1F58", "Arn"],
     },
-    FunctionName: { Ref: "TestConstructTestConstructLambdaB5C5F6AB" },
+    FunctionName: { Ref: "TestConstructLambda95D80924" },
     FunctionResponseTypes: ["ReportBatchItemFailures"],
     ScalingConfig: { MaximumConcurrency: 5 },
     BatchSize: 5,
@@ -100,8 +99,8 @@ test("should set multiple rules when ruleProps is an array", () => {
   const eventBus = EventBus.fromEventBusName(testStack, "EventBus", `mybus`);
 
   new EventBridgeSqsLambda(testStack, "TestConstruct", {
-    envPrefix: "mytest",
-    ruleProps: [
+    namesPrefix: "mytest",
+    rules: [
       {
         ruleName: "MyRule1",
         eventBus,
@@ -123,7 +122,7 @@ test("should set multiple rules when ruleProps is an array", () => {
         },
       },
     ],
-    nodejsFunctionProps: {
+    lambda: {
       entry: path.join(__dirname, "./mock/mock.lambda.js"),
     },
   });
@@ -141,7 +140,7 @@ test("should set multiple rules when ruleProps is an array", () => {
     Targets: [
       {
         Arn: {
-          "Fn::GetAtt": ["TestConstructTestConstructQueue8E078832", "Arn"],
+          "Fn::GetAtt": ["TestConstructQueue447D1F58", "Arn"],
         },
       },
     ],
@@ -158,7 +157,7 @@ test("should set multiple rules when ruleProps is an array", () => {
     Targets: [
       {
         Arn: {
-          "Fn::GetAtt": ["TestConstructTestConstructQueue8E078832", "Arn"],
+          "Fn::GetAtt": ["TestConstructQueue447D1F58", "Arn"],
         },
       },
     ],
@@ -171,8 +170,8 @@ test("should append .fifo to queues when fifo:true", () => {
   const testStack = new cdk.Stack(app, "TestStack");
 
   new EventBridgeSqsLambda(testStack, "TestConstruct", {
-    envPrefix: "mytest",
-    ruleProps: {
+    namesPrefix: "mytest",
+    rule: {
       eventBus: EventBus.fromEventBusName(testStack, "EventBus", `mybus`),
       eventPattern: {
         detailType: ["MyEvent"],
@@ -181,13 +180,13 @@ test("should append .fifo to queues when fifo:true", () => {
         },
       },
     },
-    nodejsFunctionProps: {
+    lambda: {
       entry: path.join(__dirname, "./mock/mock.lambda.js"),
     },
-    deadLetterQueueProps: {
+    queueDlq: {
       fifo: true,
     },
-    readQueueProps: {
+    queue: {
       fifo: true,
     },
   });

--- a/packages/sqs-lambda/test/eventbridge.test.ts
+++ b/packages/sqs-lambda/test/eventbridge.test.ts
@@ -14,15 +14,18 @@ test("should set all required resources", () => {
 
   new EventBridgeSqsLambda(testStack, "TestConstruct", {
     namesPrefix: "mytest",
-    rule: {
-      eventBus: EventBus.fromEventBusName(testStack, "EventBus", `mybus`),
-      eventPattern: {
-        detailType: ["MyEvent"],
-        detail: {
-          foo: "bar",
+    rules: [
+      {
+        ruleName: "MyRule1",
+        eventBus: EventBus.fromEventBusName(testStack, "EventBus", `mybus`),
+        eventPattern: {
+          detailType: ["MyEvent"],
+          detail: {
+            foo: "bar",
+          },
         },
       },
-    },
+    ],
     queue: {
       retryAttempts: 17,
     },
@@ -69,7 +72,7 @@ test("should set all required resources", () => {
       "detail-type": ["MyEvent"],
       detail: { foo: "bar" },
     },
-    Name: "mytest-TestConstructRule",
+    Name: "mytest-TestConstructMyRule1",
     State: "ENABLED",
     Targets: [
       {
@@ -135,7 +138,7 @@ test("should set multiple rules when ruleProps is an array", () => {
       "detail-type": ["MyEvent"],
       detail: { foo: "bar" },
     },
-    Name: "MyRule1",
+    Name: "mytest-TestConstructMyRule1",
     State: "ENABLED",
     Targets: [
       {
@@ -152,7 +155,7 @@ test("should set multiple rules when ruleProps is an array", () => {
       "detail-type": ["MyEvent2"],
       detail: { foo: "bar2" },
     },
-    Name: "MyRule2",
+    Name: "mytest-TestConstructMyRule2",
     State: "ENABLED",
     Targets: [
       {
@@ -164,6 +167,22 @@ test("should set multiple rules when ruleProps is an array", () => {
   });
 });
 
+test("should throw when no rules are provided", (t) => {
+  const app = new cdk.App();
+
+  const testStack = new cdk.Stack(app, "TestStack");
+
+  t.assert.throws(() => {
+    new EventBridgeSqsLambda(testStack, "TestConstruct", {
+      namesPrefix: "mytest",
+      rules: [],
+      lambda: {
+        entry: path.join(__dirname, "./mock/mock.lambda.js"),
+      },
+    });
+  });
+});
+
 test("should append .fifo to queues when fifo:true", () => {
   const app = new cdk.App();
 
@@ -171,15 +190,18 @@ test("should append .fifo to queues when fifo:true", () => {
 
   new EventBridgeSqsLambda(testStack, "TestConstruct", {
     namesPrefix: "mytest",
-    rule: {
-      eventBus: EventBus.fromEventBusName(testStack, "EventBus", `mybus`),
-      eventPattern: {
-        detailType: ["MyEvent"],
-        detail: {
-          foo: "bar",
+    rules: [
+      {
+        ruleName: "MyRule1",
+        eventBus: EventBus.fromEventBusName(testStack, "EventBus", `mybus`),
+        eventPattern: {
+          detailType: ["MyEvent"],
+          detail: {
+            foo: "bar",
+          },
         },
       },
-    },
+    ],
     lambda: {
       entry: path.join(__dirname, "./mock/mock.lambda.js"),
     },
@@ -199,5 +221,180 @@ test("should append .fifo to queues when fifo:true", () => {
 
   template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: "mytest-TestConstructQueue.fifo",
+  });
+});
+
+test("should set no prefix to resource names when not provided", () => {
+  const app = new cdk.App();
+
+  const testStack = new cdk.Stack(app, "TestStack");
+
+  new EventBridgeSqsLambda(testStack, "TestConstruct", {
+    rules: [
+      {
+        ruleName: "MyRule1",
+        eventBus: EventBus.fromEventBusName(testStack, "EventBus", `mybus`),
+        eventPattern: {
+          detailType: ["MyEvent"],
+          detail: {
+            foo: "bar",
+          },
+        },
+      },
+    ],
+    queue: {
+      retryAttempts: 17,
+    },
+    queueDlq: {
+      visibilityTimeout: cdk.Duration.seconds(10),
+    },
+    lambda: {
+      entry: path.join(__dirname, "./mock/mock.lambda.js"),
+    },
+    eventSource: {
+      batchSize: 5,
+    },
+  });
+
+  const template = Template.fromStack(testStack);
+
+  template.hasResourceProperties("AWS::Lambda::Function", {
+    FunctionName: "TestConstructLambda",
+    Runtime: Match.stringLikeRegexp("nodejs"),
+    Timeout: 10,
+    Environment: {
+      Variables: {
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+    },
+  });
+
+  template.hasResourceProperties("AWS::SQS::Queue", {
+    QueueName: "TestConstructDLQueue",
+    VisibilityTimeout: 10,
+  });
+
+  template.hasResourceProperties("AWS::SQS::Queue", {
+    QueueName: "TestConstructQueue",
+    RedrivePolicy: {
+      deadLetterTargetArn: Match.anyValue(),
+      maxReceiveCount: 17,
+    },
+  });
+
+  template.hasResourceProperties("AWS::Events::Rule", {
+    EventBusName: "mybus",
+    EventPattern: {
+      "detail-type": ["MyEvent"],
+      detail: { foo: "bar" },
+    },
+    Name: "TestConstructMyRule1",
+    State: "ENABLED",
+    Targets: [
+      {
+        Arn: {
+          "Fn::GetAtt": ["TestConstructQueue447D1F58", "Arn"],
+        },
+      },
+    ],
+  });
+
+  template.hasResourceProperties("AWS::Lambda::EventSourceMapping", {
+    EventSourceArn: {
+      "Fn::GetAtt": ["TestConstructQueue447D1F58", "Arn"],
+    },
+    FunctionName: { Ref: "TestConstructLambda95D80924" },
+    FunctionResponseTypes: ["ReportBatchItemFailures"],
+    ScalingConfig: { MaximumConcurrency: 5 },
+    BatchSize: 5,
+  });
+});
+
+test("should apply global defaults to resources when provided", () => {
+  const app = new cdk.App();
+
+  const testStack = new cdk.Stack(app, "TestStack");
+
+  const nativeDefaults = EventBridgeSqsLambda.getDefaults();
+
+  EventBridgeSqsLambda.setDefaults({
+    lambda: {
+      memorySize: 512,
+    },
+    eventSource: {
+      maxConcurrency: 3,
+    },
+    rules: {
+      enabled: false,
+    },
+    queue: {
+      visibilityTimeout: cdk.Duration.seconds(18),
+    },
+    queueDlq: {
+      visibilityTimeout: cdk.Duration.seconds(19),
+    },
+    namesPrefix: "testDefaults",
+  });
+
+  new EventBridgeSqsLambda(testStack, "TestConstruct", {
+    rules: [
+      {
+        ruleName: "TestRule",
+        eventBus: EventBus.fromEventBusName(testStack, "EventBus", `mybus`),
+        eventPattern: {
+          detailType: ["MyEvent"],
+          detail: {
+            foo: "bar",
+          },
+        },
+      },
+    ],
+    lambda: {
+      entry: path.join(__dirname, "./mock/mock.lambda.js"),
+    },
+  });
+
+  const template = Template.fromStack(testStack);
+
+  EventBridgeSqsLambda.setDefaults(nativeDefaults);
+
+  template.hasResourceProperties("AWS::Lambda::Function", {
+    FunctionName: "testDefaults-TestConstructLambda",
+    MemorySize: 512,
+  });
+
+  template.hasResourceProperties("AWS::SQS::Queue", {
+    QueueName: "testDefaults-TestConstructDLQueue",
+    VisibilityTimeout: 19,
+  });
+
+  template.hasResourceProperties("AWS::SQS::Queue", {
+    QueueName: "testDefaults-TestConstructQueue",
+    VisibilityTimeout: 18,
+  });
+
+  template.hasResourceProperties("AWS::Events::Rule", {
+    EventBusName: "mybus",
+    EventPattern: {
+      "detail-type": ["MyEvent"],
+      detail: { foo: "bar" },
+    },
+    Name: "testDefaults-TestConstructTestRule",
+    State: "DISABLED",
+    Targets: [
+      {
+        Arn: {
+          "Fn::GetAtt": ["TestConstructQueue447D1F58", "Arn"],
+        },
+      },
+    ],
+  });
+
+  template.hasResourceProperties("AWS::Lambda::EventSourceMapping", {
+    EventSourceArn: {
+      "Fn::GetAtt": ["TestConstructQueue447D1F58", "Arn"],
+    },
+    FunctionName: { Ref: "TestConstructLambda95D80924" },
+    ScalingConfig: { MaximumConcurrency: 3 },
   });
 });


### PR DESCRIPTION
### BRAKING CHANGE! this will be version 1.0.0

The initial release (v0.0.1) is compatible with current implementations.  This new one drops some ad-hoc configurations to be more general-purpose but is incompatible with the previous version. The props have been simplified and made more flexible.

Feats:
* resource naming was fixed and improved, no more repeated names. Outside-the-box default management.
* rules are always passed as an array, this simplifies typings. It only adds a few braces in single-rule implementation ;)
* adds some global default management for projects where there is a need for shared properties (es lambda config).

### Example:

```TS
  // this sets the defaults for all implementations
  EventBridgeSqsLambda.setDefaults({
    lambda: {
      architecture: Architecture.ARM_64,
      runtime: Runtime.NODEJS_20_X,
    },
    namesPrefix: "test", // your env prefix
  });

  new EventBridgeSqsLambda(testStack, "TestConstruct", {
    rules: [
      {
        ruleName: "TestRule",
        eventBus: EventBus.fromEventBusName(testStack, "EventBus", `mybus`),
        eventPattern: {
          detailType: ["MyEvent"],
        },
      },
    ],
    lambda: {
      entry: path.join(__dirname, "./lambda.js"),
    },
  });

  new EventBridgeSqsLambda(testStack, "TestConstruct2", {
    rules: [
      {
        ruleName: "TestRule2",
        eventBus: EventBus.fromEventBusName(testStack, "EventBus", `mybus`),
        eventPattern: {
          detailType: ["MyEvent2"],
        },
      },
    ],
    lambda: {
      entry: path.join(__dirname, "./lambda2.js"),
    },
  });

```
they will both run in nodejs 20 (ARM) and have all resource names prefixed with `test-`.