### PR TITLE
fix(sqs-lambda): fix duplicate "rule" in physical name

### DIFF
--- a/packages/sqs-lambda/src/eventbridge.ts
+++ b/packages/sqs-lambda/src/eventbridge.ts
@@ -117,7 +117,7 @@ export class EventBridgeSqsLambda extends Construct {
   }
 
   addRule(ruleName: string, ruleProps: EventBridgeSqsLambdaRuleProps) {
-    const rule = new Rule(this, `${ruleName}Rule`, {
+    const rule = new Rule(this, ruleName, {
       ruleName,
       ...ruleProps,
     });


### PR DESCRIPTION
The suffix "Rule" was applied 2 times.